### PR TITLE
ci: simplify GitHub Actions workflows

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -25,13 +25,6 @@ jobs:
           fetch-depth: 1
           submodules: 'recursive'
 
-      - name: Setup Python
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: '3.10'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          cache: 'pip' # caching pip dependencies
-
       - uses: actions/labeler@v5
         continue-on-error: true
 

--- a/.github/workflows/pre-commit-updater.yml
+++ b/.github/workflows/pre-commit-updater.yml
@@ -26,13 +26,6 @@ jobs:
           fetch-depth: 1
           submodules: 'recursive'
 
-      - name: Setup Python
-        uses: actions/setup-python@v5.1.0
-        with:
-          python-version: '3.10'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          cache: 'pip' # caching pip dependencies
-
       - name: Update Pre-Commit
         uses: browniebroke/pre-commit-autoupdate-action@main
 

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -1,6 +1,3 @@
-# This action has been disabled since it is not frequently used.
-# Just leave it for the sake of the example.
-
 name: Release Drafter
 
 on:


### PR DESCRIPTION
## What does this PR do?

- Remove Python setup step from `code-quality-check` and `pre-commit-updater` workflows
- Delete initial comment block from `release_drafter` workflow indicating it's unused
