### PR TITLE
ci: streamline version handling in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Get the version
         if: github.ref == 'refs/tags/v*'
         id: metadata
-        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+        uses: battila7/get-version-action@v2
 
       - name: Check Files
         run: |

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Get the version
         if: github.ref == 'refs/tags/v*'
         id: metadata
-        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+        uses: battila7/get-version-action@v2
 
       - name: Build and Push Base Image
         if: github.ref == 'refs/tags/v*'

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -46,6 +46,28 @@ jobs:
           ~/.rye/shims/rye sync
           ~/.rye/shims/rye --version
 
+      - name: Get the version
+        if: github.ref == 'refs/tags/v*'
+        id: metadata
+        uses: battila7/get-version-action@v2
+
+      - name: Updaste Version
+        if: github.ref == 'refs/tags/v*'
+        run: |
+          ~/.rye/shims/rye version ${{ steps.metadata.outputs.version }}
+
       - name: Build Package
         run: |
           ~/.rye/shims/rye build --clean
+
+      # - name: Upload Release Assets
+      #   if: startsWith(github.ref, 'refs/tags/v')
+      #   uses: softprops/action-gh-release@v2
+      #   # continue-on-error: true
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     name: ${{ steps.drafter.outputs.name }}
+      #     tag_name: ${{ steps.drafter.outputs.tag_name }}
+      #     files: |
+      #       ./dist/*

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -60,14 +60,22 @@ jobs:
         run: |
           ~/.rye/shims/rye build --clean
 
-      # - name: Upload Release Assets
-      #   if: startsWith(github.ref, 'refs/tags/v')
-      #   uses: softprops/action-gh-release@v2
-      #   # continue-on-error: true
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     name: ${{ steps.drafter.outputs.name }}
-      #     tag_name: ${{ steps.drafter.outputs.tag_name }}
-      #     files: |
-      #       ./dist/*
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4.3.3
+        with:
+          path: ./dist/*
+          name: ${{ github.event.repository.name }}-packages
+          if-no-files-found: ignore
+          retention-days: 90
+          compression-level: 6
+          overwrite: true
+
+      - name: Upload Release Assets
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            ./dist/*


### PR DESCRIPTION
## What does this PR do?

- Replace direct echo version output with `get-version-action` in GitHub Action workflows for build and build image
- Add steps to get the version and update it using `rye` in build package workflow
- Comment out the 'Upload Release Assets' section in build package workflow
