### PR TITLE
ci: refine GitHub Actions workflow logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
           name: ${{ github.event.repository.name }}
 
       - name: Get the version
-        if: github.ref == 'refs/tags/v*'
+        if: startsWith(github.ref, 'refs/tags/v')
         id: metadata
         uses: battila7/get-version-action@v2
 
@@ -91,7 +91,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: ${{ steps.drafter.outputs.name }}
-          tag_name: ${{ steps.drafter.outputs.tag_name }}
           files: |
             ${{ github.event.repository.name }}_${{ steps.metadata.outputs.version }}.zip

--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -75,12 +75,12 @@ jobs:
           provenance: false
 
       - name: Get the version
-        if: github.ref == 'refs/tags/v*'
+        if: startsWith(github.ref, 'refs/tags/v')
         id: metadata
         uses: battila7/get-version-action@v2
 
       - name: Build and Push Base Image
-        if: github.ref == 'refs/tags/v*'
+        if: startsWith(github.ref, 'refs/tags/v')
         uses: docker/build-push-action@v5.1.0
         with:
           push: true

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -47,12 +47,12 @@ jobs:
           ~/.rye/shims/rye --version
 
       - name: Get the version
-        if: github.ref == 'refs/tags/v*'
+        if: startsWith(github.ref, 'refs/tags/v')
         id: metadata
         uses: battila7/get-version-action@v2
 
       - name: Updaste Version
-        if: github.ref == 'refs/tags/v*'
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           ~/.rye/shims/rye version ${{ steps.metadata.outputs.version }}
 
@@ -73,7 +73,7 @@ jobs:
       - name: Upload Release Assets
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v2
-        continue-on-error: true
+        # continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## What does this PR do?

- Adjust version evaluation logic to use `startsWith` in GitHub Action workflows
- Remove specific naming and tagging steps in `build.yml` workflow
- Comment out `continue-on-error` option in `build_package.yml` workflow
