### PR TITLE
ci: optimize CI workflows and enhance distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           path: ./dist/*
           name: ${{ github.event.repository.name }}
           if-no-files-found: ignore
-          retention-days: 90
+          retention-days: 7
           compression-level: 6
           overwrite: true
 

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -66,7 +66,7 @@ jobs:
           path: ./dist/*
           name: ${{ github.event.repository.name }}-packages
           if-no-files-found: ignore
-          retention-days: 90
+          retention-days: 7
           compression-level: 6
           overwrite: true
 
@@ -79,3 +79,17 @@ jobs:
         with:
           files: |
             ./dist/*
+
+      - name: Publish package distributions to PyPI
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        continue-on-error: true
+        with:
+          user: ${{ secrets.PYPI_USERNAME }}
+          password: ${{ secrets.PYPI_PASSWORD }}
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: ./dist
+          verify-metadata: true
+          skip-existing: true
+          verbose: true
+          print-hash: true


### PR DESCRIPTION
## What does this PR do?

- Reduce artifact retention days from `90` to `7` in `build.yml` workflow
- Reduce artifact retention days from `90` to `7` in `build_package.yml` workflow
- Add steps to publish package distributions to PyPI when a version tag is pushed in `build_package.yml` workflow
